### PR TITLE
bugfix: `postgis` extension not found in `osx-arm64` installs

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,10 +12,12 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -99,7 +100,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-build_platform:
-  osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
 conda_build_tool: rattler-build
@@ -8,4 +6,6 @@ conda_install_tool: pixi
 github:
   branch_name: main
   tooling_branch_name: main
+provider:
+  osx_arm64: default
 test: native_and_emulated

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,11 +5,11 @@
 
 [workspace]
 name = "postgis-feedstock"
-version = "3.60.0"  # conda-smithy version used to generate this file
+version = "3.61.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/postgis-feedstock"
 authors = ["@conda-forge/postgis"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "osx-64", "win-64"]
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 requires-pixi = ">=0.59.0"
 
 [dependencies]

--- a/recipe/pg_config.wrapper
+++ b/recipe/pg_config.wrapper
@@ -20,7 +20,7 @@ get_mkvar() {
             printf '%s\n' "${PREFIX}/lib"
             ;;
         sharedir)
-            printf '%s\n' "${PREFIX}/share/postgresql"
+            printf '%s\n' "${PREFIX}/share"
             ;;
         includedir)
             printf '%s\n' "${PREFIX}/include"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 3ab7714ff1d0f7944855d21546d24e5f7ecf6b931c72472a2bfa30e188a33093
 
 build:
-  number: 0
+  number: 1
   skip: win
 
 requirements:


### PR DESCRIPTION
Is anyone else running across issues using `postgis` on `osx-arm64`? If so, I think this could be a fix for it.

Could someone else please test and review this before we merge?

cc: @xylar, @dwnoble, @mxr-conda, and @sodre 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

#### Problem
When installing `postgis` from conda-forge on `osx-arm64`, running `CREATE EXTENSION postgis` in PostgreSQL fails because the extension files cannot be found. Building this natively (without the wrapper) builds successfully.

#### Root Cause

The conda-forge CI builds `osx-arm64` packages from `osx-64` runners (cross-compilation). When `build.sh` detects `build_platform != target_platform`, it substitutes `pg_config.wrapper` for the real `pg_config` binary.

The wrapper had `--sharedir` hardcoded to `${PREFIX}/share/postgresql`:
```bash
sharedir)
    printf '%s\n' "${PREFIX}/share/postgresql"
    ;;
```
However, the real pg_config --sharedir from the conda-forge postgresql package returns ${PREFIX}/share — without the /postgresql suffix.

This happens because the postgresql package itself is compiled with a build path containing the word postgresql (e.g. .../postgresql-split_1772135725821/...). The PGXS Makefile.global has logic that only appends /postgresql to datadir when the string postgres is not already present in the path. Since it is present in the conda build path, the override is skipped, and pg_config --sharedir ends up returning ${prefix}/share.

At runtime, PostgreSQL calls pg_config --sharedir and looks for extensions under <sharedir>/extension/. Since the real pg_config returns share (not share/postgresql), it looks in share/extension/ — the location used by the native build, not the cross-compiled one.

#### Fix

Change recipe/pg_config.wrapper to return ${PREFIX}/share for --sharedir, matching what the real pg_config binary returns:

```diff
-        printf '%s\n' "${PREFIX}/share/postgresql"
+        printf '%s\n' "${PREFIX}/share"
```

This ensures that cross-compiled builds install extension files to the same location as native builds, so CREATE EXTENSION postgis works correctly regardless of how the package was built.

#### Testing

- Build the package locally with rattler-build and verify CREATE EXTENSION postgis works.
- The existing run_test.sh test exercises extension loading and should catch regressions.